### PR TITLE
Add url pattern for update_certificate

### DIFF
--- a/accredible_certificate/urls.py
+++ b/accredible_certificate/urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls import url
 from views import request_certificate
+from views import update_certificate
 
 
 urlpatterns = [
-    url(r'^request_certificate$', request_certificate, name='request_certificate')
+    url(r'^request_certificate$', request_certificate, name='request_certificate'),
+    url(r'^update_certificate$', update_certificate, name='update_certificate')
 ]


### PR DESCRIPTION
Evidently the tool already supports updating a certificate, but for some reason the url pattern was never implemented. This feature will be useful if a student takes an exam and passes on the first try with a minimum grade of 85%, but decides to take the exam again to get a better grade. The current implementation logs the first exam grade in Accredible. See https://github.com/gymnasium/tracker/issues/44 for additional issue details.