### PR TITLE
[Bug fix]: update cert.download_url to credential.net

### DIFF
--- a/accredible_certificate/queue.py
+++ b/accredible_certificate/queue.py
@@ -239,7 +239,7 @@ class CertificateGeneration(object):
                         cert.status = defined_status
                         cert.key = json_response["credential"]["id"]
                         if 'private' in json_response:
-                            cert.download_url = "https://wwww.credential.net/" + \
+                            cert.download_url = "https://www.credential.net/" + \
                                 str(json_response["credential"]["id"]) + \
                                 "?key" + str(json_response["private_key"])
                         else:

--- a/accredible_certificate/queue.py
+++ b/accredible_certificate/queue.py
@@ -239,11 +239,11 @@ class CertificateGeneration(object):
                         cert.status = defined_status
                         cert.key = json_response["credential"]["id"]
                         if 'private' in json_response:
-                            cert.download_url = "https://wwww.accredible.com/" + \
+                            cert.download_url = "https://wwww.credential.net/" + \
                                 str(json_response["credential"]["id"]) + \
                                 "?key" + str(json_response["private_key"])
                         else:
-                            cert.download_url = "https://www.accredible.com/" + \
+                            cert.download_url = "https://www.credential.net/" + \
                                 str(cert.key)
                         cert.save()
                     else:


### PR DESCRIPTION
Replaces `accredible.com` with `credential.net` to resolve the 404 issue with certificate download URLs.

See https://github.com/gymnasium/tracker/issues/317 for additional details.